### PR TITLE
ListEditor を開いた後、インベントリを開きアイテムスロットをクリックするとクラッシュするバグを修正

### DIFF
--- a/src/org/yogpstop/qp/client/GuiList.java
+++ b/src/org/yogpstop/qp/client/GuiList.java
@@ -69,4 +69,11 @@ public class GuiList extends GuiScreen {
 		}
 		super.drawScreen(i, j, k);
 	}
+
+    @Override
+    protected void keyTyped(char par1, int par2) {
+        if (par2 == 1 || par1 == 'e') {
+            this.mc.thePlayer.closeScreen();
+        }
+    }
 }


### PR DESCRIPTION
表題の通りのバグが発生しました。
サーバー側で ContainerDummy を開いているのにもかかわらず、クライアント側では GuiContainer のサブクラスではなく、 GuiScreen のサブクラスを開いているので、GuiContainer#mc.thePlayer.closeScreen() が呼ばれず、サーバー側では ListEditor が開きっぱなしになっているからだと思われます。
取り込むか修正をお願いします。
